### PR TITLE
[Feat] 유저 로그인 & 토큰 & uuid 관련 상태관리 코드 작성 및 버그 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,13 +7,6 @@ import Router from './pages/Router';
 import { CookiesProvider } from 'react-cookie';
 
 function App() {
-  let vh = 0;
-
-  useEffect(() => {
-    vh = window.innerHeight * 0.01;
-    document.documentElement.style.setProperty('--vh', `${vh}px`);
-  }, []);
-
   return (
     <>
       <GlobalStyle />

--- a/src/components/member/ButtonContainer.jsx
+++ b/src/components/member/ButtonContainer.jsx
@@ -3,9 +3,10 @@ import { useNavigate } from 'react-router-dom';
 import { useRedirectPage } from '../../hooks/useRedirectPage';
 import styled from 'styled-components';
 
-function ButtonContainer({ isMyPage, myUid, isMatchUid, isLoggedUser }) {
+function ButtonContainer({ isMyPage, myUid, isLoggedUser }) {
   const navigate = useNavigate();
   const [setPage] = useRedirectPage();
+
   return (
     <ButtonConatinerWrap>
       {isMyPage && (
@@ -15,7 +16,19 @@ function ButtonContainer({ isMyPage, myUid, isMatchUid, isLoggedUser }) {
         </button>
       )}
 
-      {isLoggedUser && !isMatchUid && (
+      {!isLoggedUser && (
+        <>
+          <button onClick={setPage.bind(this, `/customFish/`)}>
+            <img src="./assets/images/member/button.png" alt="붕어빵 만들기 버튼" />
+            <span>붕어빵 만들기</span>
+          </button>
+          <button onClick={setPage.bind(this, `/`)} className="buttonLink">
+            <span>로그인 하러 가기</span>
+          </button>
+        </>
+      )}
+
+      {!isMyPage && isLoggedUser && (
         <>
           <button onClick={setPage.bind(this, `/customFish/`)}>
             <img src="./assets/images/member/button.png" alt="붕어빵 만들기 버튼" />
@@ -31,18 +44,6 @@ function ButtonContainer({ isMyPage, myUid, isMatchUid, isLoggedUser }) {
           </button>
         </>
       )}
-
-      {!isLoggedUser && (
-        <>
-          <button onClick={setPage.bind(this, `/customFish/`)}>
-            <img src="./assets/images/member/button.png" alt="붕어빵 만들기 버튼" />
-            <span>붕어빵 만들기</span>
-          </button>
-          <button onClick={setPage.bind(this, `/`)} className="buttonLink">
-            <span>로그인 하러 가기</span>
-          </button>
-        </>
-      )}
     </ButtonConatinerWrap>
   );
 }
@@ -50,7 +51,7 @@ function ButtonContainer({ isMyPage, myUid, isMatchUid, isLoggedUser }) {
 export default ButtonContainer;
 
 // 버튼 박스
-const ButtonConatinerWrap = styled.div`
+const ButtonConatinerWrap = styled.section`
   button {
     width: 100%;
     height: 70px;
@@ -67,6 +68,10 @@ const ButtonConatinerWrap = styled.div`
 
     img {
       width: 100%;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
     }
 
     span {
@@ -74,6 +79,7 @@ const ButtonConatinerWrap = styled.div`
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
+      white-space: nowrap;
     }
 
     &:hover {
@@ -82,7 +88,7 @@ const ButtonConatinerWrap = styled.div`
   }
 
   .buttonLink {
-    height: 50px;
+    height: 70px;
     background: transparent;
     color: #73390b;
 
@@ -90,6 +96,8 @@ const ButtonConatinerWrap = styled.div`
       display: inline-block;
       line-height: 28px;
       border-bottom: 2px solid #73390b;
+
+      white-space: nowrap;
     }
 
     &:hover {

--- a/src/components/member/FishBreadTruck.jsx
+++ b/src/components/member/FishBreadTruck.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useRedirectPage } from '../../hooks/useRedirectPage';
 import styled from 'styled-components';
 
-function FishBreadTruck({ displayFishImage, uid }) {
+function FishBreadTruck({ displayFishImage, isMyPage, pageUuid }) {
   const [setPage] = useRedirectPage();
   return (
     <FishBreadTruckWrap>
@@ -10,8 +10,8 @@ function FishBreadTruck({ displayFishImage, uid }) {
         <img
           src={`./assets/images/member/${displayFishImage}`}
           alt="고양이 트럭이다냥"
-          className={'catTruck clickable'}
-          onClick={setPage.bind(this, `/list/${uid}`)}
+          className={isMyPage ? 'catTruck clickable' : 'catTruck '}
+          onClick={isMyPage ? setPage.bind(this, `/list/${pageUuid}`) : null}
         />
       </FishBreadTruckBox>
     </FishBreadTruckWrap>
@@ -20,12 +20,12 @@ function FishBreadTruck({ displayFishImage, uid }) {
 
 export default FishBreadTruck;
 
-const FishBreadTruckWrap = styled.div`
+const FishBreadTruckWrap = styled.section`
   width: 100%;
-  height: 50%;
+  height: 47%;
   position: relative;
 
-  margin-bottom: 2%;
+  margin-bottom: 3%;
 `;
 
 const FishBreadTruckBox = styled.div`
@@ -40,5 +40,8 @@ const FishBreadTruckBox = styled.div`
     bottom: 0;
     left: 50%;
     transform: translateX(-50%);
+  }
+  .clickable {
+    cursor: pointer;
   }
 `;

--- a/src/components/member/SectionTitle.jsx
+++ b/src/components/member/SectionTitle.jsx
@@ -1,11 +1,10 @@
-import React, { useRef, useState, useEffect } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import useAxios from '../../hooks/useAxios';
 import styled from 'styled-components';
 
-function SectionTitle({ fishSizeAll, isMyPage }) {
-  const { requestApi } = useAxios();
+function SectionTitle({ fishSizeAll, isMyPage, logout, user }) {
   const [isEditMode, setIsEditMode] = useState(false);
-  const [userName, setUserName] = useState(JSON.parse(localStorage.getItem('user')).nickname);
+  const [userName, setUserName] = useState(user.nickname);
   const [newUserName, setNewUserName] = useState();
   const [randomComment, setRandomCommnet] = useState();
   const copyUrlRef = useRef();
@@ -73,26 +72,16 @@ function SectionTitle({ fishSizeAll, isMyPage }) {
     setRandomCommnet(currentComment);
 
     timeout = setTimeout(() => {
+      clearTimeout(timeout);
+
       refreshComment();
-    }, 3000);
+    }, 5000);
   };
 
   useEffect(() => {
     refreshComment();
     return () => clearTimeout(timeout);
   }, []);
-
-  const logout = async () => {
-    const { status } = await requestApi('post', 'oauth/logout/kakao');
-    try {
-      if (status === 200) {
-        localStorage.removeItem('user');
-        navigate('/');
-      }
-    } catch (error) {
-      console.log(error.code);
-    }
-  };
 
   return (
     <SectionTitleWrap>
@@ -120,9 +109,13 @@ function SectionTitle({ fishSizeAll, isMyPage }) {
 
       <div className="right">
         {/* url 복사 */}
-        <CopyUrlWrap onClick={copyUrl}>
+        <CopyUrlWrap>
           <input id="copyUrl" type="text" ref={copyUrlRef} defaultValue={window.location.href} />
-          <img src="./assets/images/member/link_button.png" alt="링크 복사 버튼" />
+          <img
+            src="./assets/images/member/link_button.png"
+            alt="링크 복사 버튼"
+            onClick={copyUrl}
+          />
           <button onClick={logout}>로그아웃</button>
         </CopyUrlWrap>
       </div>

--- a/src/pages/login/Index.jsx
+++ b/src/pages/login/Index.jsx
@@ -1,15 +1,39 @@
-import { REST_API_KEY, REDIRECT_URI } from './OAuth';
-import font from '../../../public/assets/font/font.css';
+import { useState } from 'react';
 import styled from 'styled-components';
+
+import { REST_API_KEY, REDIRECT_URI } from './OAuth';
+import { getUser, isTokenExpired } from '../../utils/userAuth';
 import { useRedirectPage } from '../../hooks/useRedirectPage';
+import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
 
 function Login() {
   const [setPage] = useRedirectPage();
+  const user = getUser();
+  const navigate = useNavigate();
+
+  /** 랜딩 페이지에서 토큰 확인 후 리디렉션합니다. */
+  const redirectHandler = () => {
+    if (!user) return;
+
+    const token = user.token;
+    if (!token) return;
+
+    const isExpired = isTokenExpired(token);
+    if (isExpired) return localStorage.removeItem('user');
+
+    navigate(`/${user.uuid}`);
+  };
+
   const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
 
   const onClickKakaoLoginButton = () => {
-    window.location.replace(KAKAO_AUTH_URL);
+    window.location.href = KAKAO_AUTH_URL;
   };
+
+  useEffect(() => {
+    redirectHandler();
+  }, [redirectHandler]);
 
   return (
     <LoginWrap>
@@ -35,7 +59,7 @@ function Login() {
 export default Login;
 
 const LoginWrap = styled.div`
-  height: calc(var(--vh, 1vh) * 100);
+  height: 100vh;
 
   background: linear-gradient(to bottom, #e3edf2 68%, #000 68%, #000 68.3%, #faeac7 68.3%);
 
@@ -56,7 +80,7 @@ const LoginWrap = styled.div`
 
   .imageWrap {
     width: 100%;
-    height: 50vh;
+    height: 47%;
     position: relative;
 
     margin-top: 5vh;
@@ -113,8 +137,8 @@ const IntroTitle = styled.h1`
 
 const KakaoLogin = styled.button`
   width: 100%;
-  max-height: 55px;
-  border-radius: 5px;
+  height: 70px;
+  border-radius: 10px;
   overflow: hidden;
 
   margin-bottom: 55px;
@@ -126,6 +150,8 @@ const KakaoLogin = styled.button`
   transition: all 0.2s;
   background-color: #fee500;
 
+  position: relative;
+
   &:hover {
     opacity: 0.9;
     transform: translateY(-2px) scale(1.01);
@@ -135,31 +161,8 @@ const KakaoLogin = styled.button`
 
 const KakaoLoginImage = styled.img`
   width: 100%;
-`;
-
-// 버튼 박스
-const ButtonConatiner = styled.div`
-  width: 100%;
-  button {
-    width: 100%;
-    height: 70px;
-
-    padding: 0;
-    background-color: transparent;
-    border: none;
-    cursor: pointer;
-
-    font-size: 18px;
-    line-height: 28px;
-    font-weight: 700;
-
-    color: #ffffff;
-    background: url('./assets/images/member/button.png') no-repeat center / contain;
-
-    transition: all 0.2s;
-
-    &:hover {
-      transform: translateY(-2px);
-    }
-  }
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
 `;

--- a/src/pages/login/KakaoLogin.jsx
+++ b/src/pages/login/KakaoLogin.jsx
@@ -5,6 +5,7 @@ import useAxios from '../../hooks/useAxios';
 import font from '../../../public/assets/font/font.css';
 import styled from 'styled-components';
 import { REST_API_KEY, REDIRECT_URI } from './OAuth';
+import { saveUser } from '../../utils/userAuth';
 
 const KakaoLogin = () => {
   const location = useLocation();
@@ -21,14 +22,7 @@ const KakaoLogin = () => {
     });
 
     if (status >= 200 && status < 400) {
-      localStorage.setItem(
-        'user',
-        JSON.stringify({
-          nickname: data.nickname,
-          token: data.token,
-          uuid: data.uuid,
-        }),
-      );
+      saveUser(data);
       navigate(`/${data.uuid}`);
     }
   };

--- a/src/pages/member/Member.jsx
+++ b/src/pages/member/Member.jsx
@@ -1,72 +1,121 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useAxios from '../../hooks/useAxios';
+import styled from 'styled-components';
+
 import * as countFishTruckImages from './countFishTruckImages.json';
 import SectionTitle from '../../components/member/SectionTitle';
 import ButtonContainer from '../../components/member/ButtonContainer';
 import FishBreadTruck from '../../components/member/FishBreadTruck';
-import styled from 'styled-components';
 
-function Member(props) {
-  const { countUp, setCountUp } = props;
-  // const { requestApi } = useAxios();
+import { getUser, hasToken, isTokenExpired } from '../../utils/userAuth';
 
-  // 사용자 일치 여부 확인
-  const [isLoggedUser, setIsLoggedUser] = useState(true);
-  const uid = window.location.pathname.slice(1);
-  const myUid = JSON.parse(localStorage.getItem('user')).uuid;
+function Member() {
+  const { requestApi } = useAxios();
+  const navigate = useNavigate();
+  const pageUuid = window.location.pathname.slice(1);
 
-  // uid 일치 여부 확인
-  const [isMatchUid, setisMatchUid] = useState(false);
-  let isMyPage = isLoggedUser && isMatchUid;
-
-  // // 붕어빵 개수 API호출
-  // const getFishBreadContents = async () => {
-  //   const { data, status } = await requestApi('get', '/fishbread');
-
-  //   if (status >= 200 && status < 400) {
-  //     console.log(data);
-  //   }
-  // };
-
-  // useEffect(() => {
-  //   getFishBreadContents();
-  // }, []);
+  // user={nickname: string, token: string, uuid: string}
+  const [user, setUser] = useState(getUser());
+  const [isLoggedUser, setIsLoggedUser] = useState(false);
+  const [isMatchUuid, setIsMatchUuid] = useState(false);
+  const [isMyPage, setIsMyPage] = useState(false);
 
   // title이랑 엮여 있어서 여기에 놔둠. 매대의 붕어빵 갯수 관련
   const [fishSizeAll, setFishSizeAll] = useState();
   const [displayFishImage, setDisplayFishImage] = useState('cat_truck_0.png');
 
+  const memeberCheck = (isLogin) => {
+    const matchedResult = user.uuid === pageUuid;
+
+    setIsMatchUuid(matchedResult);
+    setIsMyPage(isLogin && matchedResult);
+  };
+
+  async function logout() {
+    try {
+      await requestApi('post', 'oauth/logout/kakao');
+
+      // 요청 성공여부와 상관없이 token을 지워야 할 수 있음
+      console.log('로그아웃 되었습니다.');
+      localStorage.removeItem('user');
+    } catch (error) {
+      console.log(error);
+    } finally {
+      navigate('/');
+    }
+  }
+
+  /** user: User객체, logoutFunc: 로그아웃 기능 */
+  const userTokenHandler = (user, logoutFunc) => {
+    if (!hasToken(user)) {
+      // console.log('로그인하지 않았습니다.');
+      return false;
+    } else if (isTokenExpired(user.token)) {
+      logoutFunc();
+      // console.log('토큰이 만료 되었습니다.');
+      return false;
+    } else {
+      // console.log(`로그인 상태입니다. ${user.nickname}`);
+      return true;
+    }
+  };
+
+  async function getFishSizeAll() {
+    const response = await requestApi('get', `count/${'U184ce3ac09d0003'}`);
+    try {
+      console.log(response);
+      if (response.status === 200) {
+        // setFishSizeAll()
+      }
+    } catch (error) {
+      console.log(error.code);
+    } finally {
+    }
+  }
+
   // 붕어빵 갯수 보여주기
-  const fetchSizeAll = () => {
+  let countUp = 2; // sizeAll 받아오면 이거 삭제
+  const matchCatTruckImage = (countUp) => {
     if (countUp < 6) {
       setDisplayFishImage(countFishTruckImages.default[countUp].imageURL);
     } else {
+      // 이 부분 교체
       setDisplayFishImage('cat_truck_6.png');
     }
     setFishSizeAll(countUp);
   };
 
   useEffect(() => {
-    if (uid === myUid) setisMatchUid(true);
-    fetchSizeAll();
-    location.state !== null && setisMatchUid(true);
-  }, [location]);
+    // getFishSizeAll();
+
+    matchCatTruckImage(countUp);
+    const isLogin = userTokenHandler(user, logout);
+    setIsLoggedUser(isLogin);
+
+    if (isLogin) memeberCheck(isLogin);
+  }, [location, matchCatTruckImage, userTokenHandler, setIsLoggedUser]);
 
   return (
     <>
       <MemberWrap>
         <div className="contents_area">
           {/* 타이틀 */}
-          <SectionTitle fishSizeAll={fishSizeAll} isMyPage={isMyPage} />
+          <SectionTitle fishSizeAll={fishSizeAll} isMyPage={isMyPage} user={user} logout={logout} />
 
           {/* 푸드트럭 이미지 & 붕어빵 매대 */}
-          <FishBreadTruck displayFishImage={displayFishImage} uid={uid} />
+          <FishBreadTruck
+            isMyPage={isMyPage}
+            displayFishImage={displayFishImage}
+            pageUuid={pageUuid}
+          />
 
           {/* 로그인 여부에 따라 바뀌는 버튼 */}
           <ButtonContainer
             isMyPage={isMyPage}
-            myUid={myUid}
-            isMatchUid={isMatchUid}
+            isMatchUuid={isMatchUuid}
             isLoggedUser={isLoggedUser}
+            myUid={user ? user.uuid : null}
           />
         </div>
       </MemberWrap>

--- a/src/pages/member/member.json
+++ b/src/pages/member/member.json
@@ -1,9 +1,0 @@
-[
-  {
-    "id": 0,
-    "uid": "tesetest",
-    "nickname": "냥냥이",
-    "role": "user",
-    "createdAt": "YYYY-MM-DDTHH:MM:SSZ"
-  }
-]

--- a/src/utils/userAuth.js
+++ b/src/utils/userAuth.js
@@ -1,0 +1,52 @@
+/** response의 유저 정보를 localStorage에 string으로 저장합니다. return void */
+const saveUser = (fetchedUserData) => {
+  localStorage.setItem(
+    'user',
+    JSON.stringify({
+      nickname: fetchedUserData.nickname,
+      token: fetchedUserData.token,
+      uuid: fetchedUserData.uuid,
+    }),
+  );
+};
+
+// localStorage의 user를 꺼내와서 객체 형태로 return => 닉네임/토큰/uuid
+/** 유저 정보를 객체로 return합니다. | null */
+const getUser = () => {
+  if (localStorage.getItem('user') === null) {
+    return null;
+  }
+
+  const locals = localStorage.getItem('user');
+  const user = JSON.parse(locals);
+
+  return user;
+};
+
+/** 토큰이 있는지 확인합니다.(인수로 유저 객체값이 있어야 합니다.) hasToken(user:User) */
+const hasToken = (user) => {
+  if (user === null || user === undefined) return false;
+
+  return user.token !== undefined ? true : false;
+};
+
+const jwt_decode = (token) => {
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace('-', '+').replace('_', '/');
+  return JSON.parse(window.atob(base64));
+};
+
+/** JWT 토큰을 decode해서 token이 expired 되었는지 확인합니다. */
+const isTokenExpired = (token) => {
+  const decoded = jwt_decode(token);
+
+  const today = new Date();
+  const exp = new Date(decoded.exp * 1000);
+  const isExpired = exp < today;
+
+  return isExpired;
+};
+
+const isMatchUuid = (userId, pageId) => (userId === pageId ? true : false);
+
+export { saveUser, getUser, hasToken, isTokenExpired, isMatchUuid };


### PR DESCRIPTION
## [Feat] 유저 로그인 & 토큰 & uuid 관련 상태관리 코드 작성 및 버그 수정
- 오늘자 팀 노션(코드 내용) : https://dusunax.notion.site/0dd9e8e483404bae9f9febeb34dfb2ab

## 작업 내용

### util 코드 작성 및 정리
- `src\utils\userAuth.js`
```
{ saveUser, getUser, hasToken, isTokenExpired, isMatchUuid }
```

### 로그인 페이지 - 리디렉션
- 카톡 로그인 버튼, border-radius 및 높이 재조정
- 랜딩페이지 리디렉션(토큰 여부)
```
- localStorage에 토큰(user)이 있고, 토큰이 만료되지 않았다면, 개인 링크 페이지로
- localStorage에 토큰(user)이 있고, 토큰이 만료되었다면, user를 지우고 그대로
- localStorage에 토큰(user)이 없다면 그대로
```

### 개인 링크 공유 페이지 - 기능 & api 연결
- 유저의 정보를 localStorage에 저장
- 유저의 정보를 localStorage에서 꺼내서 return
- localStorage에 토큰이 있는지 확인
- 토큰의 만료기한 확인
- 토큰 디코딩
- 유저TokenHandler
- uuid 일치 여부 return boolean
- state핸들러 ⇒ memeberCheck()
- 기타 수정 : CSS + 버그 수정 + 시멘틱 태그

### 수정 파일
![image](https://user-images.githubusercontent.com/94776135/205909410-59432d94-84d9-4adf-a1e8-3846d45d864f.png)
