### PR TITLE
[Fix] 레이아웃의 logo 클릭 시 메인으로 이동

### DIFF
--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -1,9 +1,13 @@
 import styled from 'styled-components';
 
 function Layout({ children }) {
+  const goToMain = () => {
+    location.replace('/');
+  };
+
   return (
     <StLayout>
-      <h1 className="site_title">
+      <h1 className="site_title" onClick={goToMain}>
         냥냥편지
         <div className="logo">
           <img src="/assets/images/logos/main_title.png" alt="냥냥편지" />
@@ -31,9 +35,12 @@ const StLayout = styled.main`
   justify-content: center;
 
   .site_title {
-    margin: 0 0 20px;
+    line-height: 0;
+    margin: 30px 0;
 
     text-indent: -9999px;
+
+    cursor: pointer;
 
     .logo {
       text-indent: 0px;
@@ -55,7 +62,7 @@ const StLayout = styled.main`
 
   & > .contents_area {
     width: 100%;
-    max-width: 600px;
+    max-width: 550px;
     height: calc(100% - 15vh);
 
     margin-bottom: 5vh;


### PR DESCRIPTION
### QA 리스트 내용 반영

| 분류 | 페이지 | 중요도 | 내용 |
| --- | --- | --- | --- |
| UX | 공통 | 하 |  로고 클릭시 메인 화면으로 돌아가면 좋겠습니다. |

- 로고
![image](https://user-images.githubusercontent.com/94776135/207036927-dde8e98f-3c95-4961-ade5-98cb12c8857b.png)
- 수정 파일
  - `src\pages\Layout.jsx`