### PR TITLE
[Fix] 로그인 로딩 페이지 크기 조절

### DIFF
--- a/src/pages/login/KakaoLogin.jsx
+++ b/src/pages/login/KakaoLogin.jsx
@@ -47,8 +47,10 @@ const LogoBox = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+
   width: 100%;
   height: 100%;
+  margin: 0 auto;
 `;
 
 const LogoWrap = styled.div`
@@ -56,10 +58,15 @@ const LogoWrap = styled.div`
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  width: 400px;
-  height: 400px;
+
+  flex: 0 0 60%;
+  text-align: center;
+  word-break: keep-all;
 
   .catTruck {
+    max-width: 300px;
+    width: 100%;
+
     -webkit-animation: wobble-hor-bottom 2s infinite both;
     animation: wobble-hor-bottom 2s infinite both;
 
@@ -129,6 +136,10 @@ const LoginH1 = styled.h1`
   font-family: 'EF_jejudoldam';
   font-size: 40px;
   line-height: 1.3em;
+
+  @media (max-width: 500px) {
+    font-size: 30px;
+  }
 `;
 
 export default KakaoLogin;


### PR DESCRIPTION
### QA 리스트 내용 반영

| 분류 | 페이지 | 중요도 | 내용 |
| --- | --- | --- | --- |
| UI/디자인 | 메인 | 하 |  카카오로 시작하기 버튼을 눌렀을 때, “이미지+붕어빵이 노릇노릇”가 화면을 차지하는 비율이 이전 화면에 비해 너무 큽니다. |

- 수정 내용
  - 이미지 영역을 60%로 줄이고, 텍스트는 단어로 break하고, 중앙정렬함
- 크기 조절
![image](https://user-images.githubusercontent.com/94776135/207039039-f782430d-4060-4d67-be54-82ea9a420c33.png)
- 수정 파일
  - `src\pages\login\KakaoLogin.jsx`