### PR TITLE
[Fix] 붕어빵 삭제 모달 커서 포인터 적용

### DIFF
--- a/src/components/breadDetail/detail/DetailAlert.jsx
+++ b/src/components/breadDetail/detail/DetailAlert.jsx
@@ -117,6 +117,7 @@ const Button = styled.div`
   height: 40px;
   font-size: 22px;
   color: #000;
+  cursor: pointer;
 
   ${({ btnType }) =>
     btnType === 'delete' &&


### PR DESCRIPTION
- 붕어빵 삭제 모달 활성화 시, "삭제" 또는 "취소"에 포인터 적용이 안되어있던 부분 수정.