### PR TITLE
[Ui] 붕어빵 목록 grid 가로값 수정

### DIFF
--- a/src/components/breadDetail/list/DetailList.jsx
+++ b/src/components/breadDetail/list/DetailList.jsx
@@ -148,14 +148,19 @@ const Wrapper = styled.div`
 
 const DetailListWrapper = styled.div`
   height: 100%;
-  padding: 2% 50px;
   margin: 0 auto;
 
   @media screen and (min-width: 1000px) {
-    padding: 2% 14px;
+    padding: 2% 32px;
+  }
+
+  padding: 2% 120px;
+
+  @media screen and (max-width: 800px) {
+    padding: 2% 50px;
   }
   @media screen and (max-width: 500px) {
-    padding: 2% 14px;
+    padding: 2% 32px;
   }
 
   .contents_area {

--- a/src/components/breadDetail/list/DetailListItems.jsx
+++ b/src/components/breadDetail/list/DetailListItems.jsx
@@ -83,7 +83,7 @@ const DetailListItemsWrapper = styled.div`
 
 const DetailListItemsContainer = styled.ul`
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, calc((100% - 4%) / 3));
   grid-template-rows: repeat(3, 1fr);
   width: 100%;
   height: 100%;

--- a/src/components/member/elements/Button.jsx
+++ b/src/components/member/elements/Button.jsx
@@ -20,11 +20,11 @@ export default Button;
 
 const StButton = styled(ButtonText)``;
 
-const UnReadText = styled.span`
+const UnReadText = styled.div`
   position: absolute;
   top: 50%;
   right: 0;
-  transform: translate(240%, -60%) !important;
+  transform: translate(-60%, -60%) !important;
   width: 33px;
   height: 34px;
   text-align: center;
@@ -49,7 +49,7 @@ const UnReadText = styled.span`
   @media (max-width: 280px) {
     width: 28px;
     height: 29px;
-    transform: translate(240%, -60%) !important;
+    transform: translate(-30%, -60%) !important;
 
     span {
       padding-top: 18px;

--- a/src/pages/customFishbread/CustomMessage.jsx
+++ b/src/pages/customFishbread/CustomMessage.jsx
@@ -128,7 +128,7 @@ const Paper = styled.div`
     width: 100%;
     height: 100%;
     padding: 10% 17% 18%;
-
+    border: 1px solid black;
     position: absolute;
     top: 0;
 
@@ -143,6 +143,16 @@ const Paper = styled.div`
 
     @media (max-width: 500px) {
       padding: 10% 14% 17%;
+    }
+    @media (width > 800px) {
+      @media (min-height: 1000px) {
+        height: 85%;
+      }
+    }
+    @media (width > 900px) {
+      @media (min-height: 1000px) {
+        height: 75%;
+      }
     }
     @media (max-width: 400px) {
       padding: 10% 10% 18%;
@@ -174,6 +184,10 @@ const Paper = styled.div`
     border: none;
     resize: none;
     background: none;
+    border: 1px solid black;
+    /* @media (min-width: 1000px) {
+      height: 50%;
+    } */
   }
 
   .senderNickname {


### PR DESCRIPTION
### [Ui] 붕어빵 목록 grid 가로값 수정

- 버그 상황
  - 닉네임 길이에 따라 grid 가로 길이가 달라지는 현상 발견
![image](https://user-images.githubusercontent.com/94776135/208301640-69877b97-1fd8-426a-9538-45785b6bcb35.png)
- CSS 변경
```jsx
const DetailListItemsContainer = styled.ul`
  display: grid;
  grid-template-columns: repeat(3, calc((100% - 4%) / 3)); // 1fr에서, 가로 고정으로 변경
  grid-template-rows: repeat(3, 1fr);
  width: 100%;
  height: 100%;
  gap: 12% 2%;
`;
```
- 닉네임이 긴 상황 다시 확인
![image](https://user-images.githubusercontent.com/94776135/208301703-71cb7c81-8445-44d6-b1f1-3779b9ae5e2e.png)

