### PR TITLE
[Fix] layout 페이지 z-index 삭제

### DIFF
--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -86,7 +86,7 @@ const StLayout = styled.main`
       position: fixed;
       left: 50%;
       top: 10px;
-      z-index: -9;
+      /* z-index: -9; */
       transform: translateX(calc(-100% - 220px));
 
       .logo {


### PR DESCRIPTION
- 레이아웃 페이지 z-index : -9 제거 (로고를 누르면 메인 페이지로 가야 하는데 작동하지 않아 삭제)